### PR TITLE
Fix wrong Objective-C use example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ UIImage(flagImageWithCountryCode: NSLocale.autoupdatingCurrentLocale().objectFor
 UIImage(flagImageForSpecialFlag: .World)
 ```
 ```objc
-[UIImage flagImageWithCountryCode:[[NSLocale autoupdatingCurrentLocale] objectForKey:NSLocaleCountryCode]];
+[[UIImage alloc] initWithFlagImageWithCountryCode:[[NSLocale autoupdatingCurrentLocale] objectForKey:NSLocaleCountryCode]];
 ```
 If you are just adding `FlagKit.xcassets` to you target, you can simply use the standard `UIImage/NSImage` methods:
 ```swift


### PR DESCRIPTION
Hi,

It cost me quite some time to find out that the category on UIImage specifies instance methods, not class methods as depicted in the current example. No wonder Xcode could not find this category method at first.

This PR updates the example to fix this.