### PR TITLE
:sparkles: Flag class can now instantiate flags regardless of character case

### DIFF
--- a/Sources/Swift/FlagKit.xcodeproj/project.pbxproj
+++ b/Sources/Swift/FlagKit.xcodeproj/project.pbxproj
@@ -275,6 +275,7 @@
 					};
 					3AF78CE01F31CE0400BD3D10 = {
 						CreatedOnToolsVersion = 8.3.2;
+						LastSwiftMigration = 0920;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -740,7 +741,8 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -790,7 +792,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/Sources/Swift/FlagKit/Flag.swift
+++ b/Sources/Swift/FlagKit/Flag.swift
@@ -27,7 +27,8 @@ public class Flag: NSObject {
      Returns a flag if the country code is supported, otherwise it returns nil
      */
     @objc public init?(countryCode: String) {
-        guard let image = UIImage(named: countryCode, in: FlagKit.assetBundle, compatibleWith: nil) else {
+        let cCode = countryCode.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        guard let image = UIImage(named: cCode, in: FlagKit.assetBundle, compatibleWith: nil) else {
             return nil
         }
         

--- a/Sources/Swift/FlagKitDemo-iOS/FlagTableViewCell.swift
+++ b/Sources/Swift/FlagKitDemo-iOS/FlagTableViewCell.swift
@@ -12,10 +12,10 @@ class FlagTableViewCell: UITableViewCell {
         
         backgroundColor = UIColor.clear
         
-        textLabel?.font = UIFont.systemFont(ofSize: 15, weight: UIFontWeightMedium)
+        textLabel?.font = UIFont.systemFont(ofSize: 15, weight: .medium)
         textLabel?.textColor = UIColor(red: 0.00, green: 0.15, blue: 0.16, alpha: 1.0)
         
-        detailTextLabel?.font = UIFont.systemFont(ofSize: 13, weight: UIFontWeightLight)
+        detailTextLabel?.font = UIFont.systemFont(ofSize: 13, weight: .light)
         detailTextLabel?.textColor = UIColor(red: 0.00, green: 0.15, blue: 0.16, alpha: 1.0)
         
         imageView?.contentMode = .center

--- a/Sources/Swift/FlagKitTests/FlagTests.swift
+++ b/Sources/Swift/FlagKitTests/FlagTests.swift
@@ -62,5 +62,19 @@ class FlagTests: XCTestCase {
         let bundle = Bundle(for: FlagTests.self)
         return UIImage(named: name, in: bundle, compatibleWith: nil)!
     }
+  
+    func testCountryCode() {
+        let generated = Flag(countryCode: "se")
+        XCTAssertNotNil(generated)
+        
+        let generated1 = Flag(countryCode: "Se")
+        XCTAssertNotNil(generated1)
+        
+        let generated2 = Flag(countryCode: "sE")
+        XCTAssertNotNil(generated2)
+        
+        let generated3 = Flag(countryCode: " sE ")
+        XCTAssertNotNil(generated3)
+    }
 #endif
 }


### PR DESCRIPTION
:sparkles: Flag class can now instantiate flags regardless of character cases (uppercase or lowercase). Passed countryCode is also trimmed.
:white_check_mark: Added tests
:wrench: Updated demo app to use Swift 4 syntax